### PR TITLE
fix: fix unused random number generator

### DIFF
--- a/library/captcha/captcha.go
+++ b/library/captcha/captcha.go
@@ -218,8 +218,8 @@ func (c *captcha) verify(tp, ip, name, id, answer, sender string) error {
 
 // randomCode 生成随机数验证码
 func (c *captcha) randomCode(len int) string {
-	rand.New(rand.NewSource(time.Now().Unix()))
-	var code = rand.Intn(int(math.Pow10(len)) - int(math.Pow10(len-1)))
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	var code = rng.Intn(int(math.Pow10(len)) - int(math.Pow10(len-1)))
 	return strconv.Itoa(code + int(math.Pow10(len-1)))
 }
 


### PR DESCRIPTION
代码位置：library/captcha/captcha.go:221
```go
// randomCode 生成随机数验证码
func (c *captcha) randomCode(len int) string {
        // 这里用时间戳作为种子new了一个随机数生成器，但是没有使用
	rand.New(rand.NewSource(time.Now().Unix()))
	var code = rand.Intn(int(math.Pow10(len)) - int(math.Pow10(len-1)))
	return strconv.Itoa(code + int(math.Pow10(len-1)))
}
```
用时间戳作为种子new了一个随机数生成器，但是没有使用